### PR TITLE
bugfix rf103_stream_test: async i/o requires loop

### DIFF
--- a/include/rf103.h
+++ b/include/rf103.h
@@ -89,6 +89,8 @@ int rf103_set_async_params(rf103_t *this, uint32_t frame_size,
 
 int rf103_start_streaming(rf103_t *this);
 
+int rf103_handle_events(rf103_t *this);
+
 int rf103_stop_streaming(rf103_t *this);
 
 int rf103_reset_status(rf103_t *this);

--- a/src/librf103.c
+++ b/src/librf103.c
@@ -291,6 +291,10 @@ int rf103_start_streaming(rf103_t *this)
   return 0;
 }
 
+int rf103_handle_events(rf103_t *this)
+{
+  return usb_device_handle_events(this->usb_device);
+}
 
 int rf103_stop_streaming(rf103_t *this)
 {

--- a/src/usb_device.h
+++ b/src/usb_device.h
@@ -57,6 +57,8 @@ int usb_device_free_device_list(struct usb_device_info *usb_device_infos);
 usb_device_t *usb_device_open(int index, const char* imagefile,
                               uint8_t gpio_register);
 
+int usb_device_handle_events(usb_device_t *this);
+
 void usb_device_close(usb_device_t *this);
 
 int usb_device_control(usb_device_t *this, uint8_t request, uint16_t value,

--- a/src/usb_device_internals.h
+++ b/src/usb_device_internals.h
@@ -33,6 +33,8 @@ extern "C" {
 typedef struct usb_device {
   libusb_device *dev;
   libusb_device_handle *dev_handle;
+  libusb_context *context;
+  int completed;
   int nendpoints;
 #define MAX_ENDPOINTS (16)
   struct libusb_endpoint_descriptor endpoints[MAX_ENDPOINTS];


### PR DESCRIPTION
problem was, that async i/o requires libusb_handle_events_completed() calls

* libusb_handle_events_completed() required libusb_context
* fixed the adc_read_async_callback()
* check exit in count_bytes_callback() - as long there's no reception thread
